### PR TITLE
Documentation update for the `action`  block

### DIFF
--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 
 ---
 
-* `action` supports the following:
+`action` supports the following:
 
 * `action_group` - (Required) List of action group reference resource IDs.
 * `custom_webhook_payload` - (Optional) Custom payload to be sent for all webhook payloads in alerting action.


### PR DESCRIPTION
There is an extra bullet for the `action` block inside the documentation, actually, it is the name of the block.